### PR TITLE
Case-insensitive event ID search

### DIFF
--- a/lib/event-store.js
+++ b/lib/event-store.js
@@ -29,13 +29,14 @@ class EventStore {
       }
     }
 
-    const evt = new Event(id, ...args)
-    this.byID.set(id, evt)
+    const upperID = id.toUpperCase()
+    const evt = new Event(upperID, ...args)
+    this.byID.set(upperID, evt)
     return evt
   }
 
   lookup (id) {
-    const e = this.byID.get(id)
+    const e = this.byID.get(id.toUpperCase())
     if (e === undefined) {
       throw buildInvalidEventError({eventID: id})
     }
@@ -43,7 +44,7 @@ class EventStore {
   }
 
   delete (id) {
-    if (!this.byID.delete(id)) {
+    if (!this.byID.delete(id.toUpperCase())) {
       throw buildInvalidEventError({eventID: id})
     }
   }

--- a/test/event-store.test.js
+++ b/test/event-store.test.js
@@ -34,21 +34,27 @@ describe('EventStore', function () {
     assert.equal(out.getName(), 'B')
   })
 
+  it('is case-insensitive for IDs', function () {
+    store.create('AAA', 'the event')
+    const out = store.lookup('aaa')
+    assert.equal(out.getName(), 'the event')
+  })
+
   it('throws an error for invalid IDs', function () {
     assert.throws(() => store.lookup('NOPENO00'), 'Invalid event ID')
   })
 
-  it('deletes events by ID', function () {
-    const e1 = store.create('111', 'A')
-    const e2 = store.create('222', 'B')
+  it('deletes events by case-insensitive ID', function () {
+    const e1 = store.create('111X', 'A')
+    const e2 = store.create('222Y', 'B')
 
-    assert.equal(store.lookup('111'), e1)
-    assert.equal(store.lookup('222'), e2)
+    assert.equal(store.lookup('111X'), e1)
+    assert.equal(store.lookup('222Y'), e2)
 
-    store.delete('222')
+    store.delete('222y')
 
-    assert.equal(store.lookup('111'), e1)
-    assert.throws(() => store.lookup('222'), 'Invalid event ID')
+    assert.equal(store.lookup('111X'), e1)
+    assert.throws(() => store.lookup('222Y'), 'Invalid event ID')
   })
 
   it('serializes and deserializes itself', function () {


### PR DESCRIPTION
Normalize event ID case so that `!event <id>` and `!event delete <id>` are case-insensitive. Hopefully this will make the mobile situation slightly less irritating.

/cc @k0d3k1ttn @jlitzwilson