### PR TITLE
Don't dump the full event attachment on --invite and --uninvite.

### DIFF
--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -82,7 +82,7 @@ module.exports = {
     const target = manip.toUid(argv.for || context.msg.message.user.id)
     const accepted = []
     const rejected = []
-    let message
+    let message = ''
 
     for (const yi of argv.yes) {
       if (yi === undefined) {
@@ -125,8 +125,20 @@ module.exports = {
     if (manip.handleNameArg(argv.name)) modified = true
     if (manip.handleProposeArg(target, argv.propose)) modified = true
     if (manip.handleUnproposeArg(argv.unpropose)) modified = true
-    if (manip.handleInviteArg(argv.invite)) modified = true
-    if (manip.handleUninviteArg(argv.uninvite)) modified = true
+
+    if (manip.handleInviteArg(argv.invite)) {
+      if (message.length > 0) message += '\n'
+      message += argv.invite.map(u => manip.toUid(u)).join(', ')
+      message += (argv.invite.length === 1 ? ' has ' : ' have ')
+      message += `been invited to the event "${evt.getName()}".`
+    }
+
+    if (manip.handleUninviteArg(argv.uninvite)) {
+      if (message.length > 0) message += '\n'
+      message += argv.uninvite.map(u => manip.toUid(u)).join(', ')
+      message += (argv.uninvite.length === 1 ? ' has ' : ' have ')
+      message += `been uninvited from the event "${evt.getName()}".`
+    }
 
     if (argv.finalize !== undefined) {
       evt.finalize(argv.finalize)
@@ -135,12 +147,14 @@ module.exports = {
 
     if (argv.unfinalize) {
       evt.unfinalize()
-      message = `The event "${evt.getName()}" may now have its final date reassigned.`
+      if (message.length > 0) message += '\n'
+      message += `The event "${evt.getName()}" may now have its final date reassigned.`
       modified = true
     }
 
     if (rsvp) {
-      message = 'You have confirmed that '
+      if (message.length > 0) message += '\n'
+      message += 'You have confirmed that '
       if (argv.for) {
         message += target
       } else {
@@ -176,21 +190,18 @@ module.exports = {
       }
 
       message += '.'
+    }
 
-      if (modified) {
-        context.msg.send({
-          text: message,
-          attachments: manip.renderAllAttachments()
-        })
-      } else {
-        context.msg.send(message)
+    if (modified) {
+      const payload = {
+        attachments: manip.renderAllAttachments()
       }
-    } else {
-      const payload = {attachments: manip.renderAllAttachments()}
-      if (message) {
-        payload.text = message
-      }
+      if (message.length > 0) payload.text = message
       context.msg.send(payload)
+    } else if (message.length > 0) {
+      context.msg.send(message)
+    } else {
+      context.msg.send({attachments: manip.renderAllAttachments()})
     }
   }
 }

--- a/test/edit.test.js
+++ b/test/edit.test.js
@@ -95,48 +95,12 @@ describe('event edit', function () {
 
   it('invites someone new', async function () {
     await bot.say('user0', 'hubot: event AAA111 --invite @user2')
-    assert.deepEqual(bot.response(), {
-      attachments: [{
-        fallback: 'AAA111: Something Cool',
-        title: 'AAA111 :calendar: Something Cool',
-        fields: [
-          {
-            title: 'Proposed Dates',
-            value:
-              '[0] <!date^1511078400^{date}|19 November 2017> _in a day_\n' +
-              '[1] <!date^1511596800^{date}|25 November 2017> _in 7 days_'
-          },
-          {
-            title: 'Who',
-            value: '_Responses_\n:white_square: <@U0> | :white_square: <@U1> | :white_square: <@U2>'
-          }
-        ],
-        mrkdwn_in: ['fields']
-      }]
-    })
+    assert.deepEqual(bot.response(), '<@U2> has been invited to the event "Something Cool".')
   })
 
   it('uninvites someone', async function () {
     await bot.say('user0', 'hubot: event AAA111 --uninvite @user1')
-    assert.deepEqual(bot.response(), {
-      attachments: [{
-        fallback: 'AAA111: Something Cool',
-        title: 'AAA111 :calendar: Something Cool',
-        fields: [
-          {
-            title: 'Proposed Dates',
-            value:
-              '[0] <!date^1511078400^{date}|19 November 2017> _in a day_\n' +
-              '[1] <!date^1511596800^{date}|25 November 2017> _in 7 days_'
-          },
-          {
-            title: 'Who',
-            value: '_Responses_\n:white_square: <@U0>'
-          }
-        ],
-        mrkdwn_in: ['fields']
-      }]
-    })
+    assert.deepEqual(bot.response(), '<@U1> has been uninvited from the event "Something Cool".')
   })
 
   it('changes its name', async function () {


### PR DESCRIPTION
This should make it a lot less chatty and @-mention-y when we invite a ton of people to an event and let them opt out.

/cc @k0d3k1ttn 