### PR TITLE
Accept --finalize with no arguments 

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ To modify an event after it's created, call `hubot: event` with the ID it's been
 
 * `hubot: event ABC123 --finalize 1`. Choose one of the event's proposed dates as its final date. Everyone who previously replied with `--yes 1` will automatically be converted to a "yes" for that date; everyone who responded with a different date will be converted to a "no".
 
+* `hubot: event ABC123 --finalize`. Choose the _only_ proposed date as its final one.
+
 * `hubot: event ABC123 --at 2018-04-01`. Propose and finalize a new date for the event at the same time.
 
 * `hubot: event ABC123 --unfinalize`. Reverse a finalization to allow you to pick a different date.

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -11,6 +11,8 @@ function elided (parts) {
   }
 }
 
+const OMITTED = Symbol('omitted')
+
 module.exports = {
   command: ['edit <id>', '*'],
 
@@ -46,7 +48,7 @@ module.exports = {
       .option('finalize', {
         describe: 'Choose the final date of the event.',
         number: true,
-        requiresArg: true
+        default: OMITTED
       })
       .option('unfinalize', {
         describe: 'Unchoose the final date.',
@@ -144,7 +146,7 @@ module.exports = {
       message += `been uninvited from the event "${evt.getName()}".`
     }
 
-    if (argv.finalize !== undefined) {
+    if (argv.finalize !== OMITTED) {
       evt.finalize(argv.finalize)
       modified = true
     }

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -15,6 +15,22 @@ module.exports = {
     })
   },
 
+  buildNoProposalsError ({eventID, eventName}) {
+    return buildError({
+      message: 'No proposed dates',
+      reply: `Event "${eventName}" has no proposed dates.`,
+      eventID
+    })
+  },
+
+  buildMultipleProposalsError ({eventID, eventName, proposalCount}) {
+    return buildError({
+      message: 'More than one proposed date',
+      reply: `Event "${eventName}" has ${proposalCount} proposed dates, so you must specify one to finalize the event.`,
+      eventID
+    })
+  },
+
   buildUnfinalizedEventError ({eventID, eventName}) {
     return buildError({
       message: 'Event not finalized',

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,4 +1,10 @@
-const {buildInvalidProposalError, buildUnfinalizedEventError, buildFinalizedEventError} = require('./errors')
+const {
+  buildInvalidProposalError,
+  buildUnfinalizedEventError,
+  buildFinalizedEventError,
+  buildNoProposalsError,
+  buildMultipleProposalsError
+} = require('./errors')
 const {Timespan} = require('./timespan')
 
 class Proposal {
@@ -152,6 +158,17 @@ class Event {
   }
 
   finalize (index) {
+    if (index === undefined || index === null) {
+      const keys = this.proposalKeys()
+      if (keys.length === 0) {
+        throw buildNoProposalsError({eventID: this.id, eventName: this.name})
+      }
+      if (keys.length > 1) {
+        throw buildMultipleProposalsError({eventID: this.id, eventName: this.name, proposalCount: keys.length})
+      }
+      index = keys[0]
+    }
+
     if (this.proposals[index] === undefined) {
       throw buildInvalidProposalError({
         eventID: this.id,

--- a/test/edit.test.js
+++ b/test/edit.test.js
@@ -327,6 +327,36 @@ describe('event edit', function () {
     })
   })
 
+  it('finalizes an unfinalized event with a single proposed date', async function () {
+    await bot.say('user0', 'hubot: event AAA111 --unpropose 0')
+    await bot.say('user0', 'hubot: event AAA111 --finalize')
+    assert.deepEqual(bot.response(), {
+      attachments: [{
+        fallback: 'AAA111: Something Cool',
+        title: 'AAA111 :calendar: Something Cool',
+        fields: [
+          {
+            title: 'When',
+            value: '<!date^1511596800^{date}|25 November 2017> _in 7 days_'
+          },
+          {
+            title: 'Who',
+            value: '_Attendees (0 confirmed)_\n:grey_question: <@U0> | :grey_question: <@U1>'
+          }
+        ],
+        mrkdwn_in: ['fields']
+      }]
+    })
+  })
+
+  it('requires an explicit finalization index with multiple proposed dates', async function () {
+    await bot.say('user0', 'hubot: event AAA111 --finalize')
+    assert.equal(
+      bot.response(),
+      ':rotating_light: Event "Something Cool" has 2 proposed dates, so you must specify one to finalize the event.'
+    )
+  })
+
   it('finalizes an unfinalized event at a new date', async function () {
     await bot.say('user0', 'hubot: event AAA111 --at 2017-11-20')
     assert.deepEqual(bot.response(), {


### PR DESCRIPTION
If an event has a single proposed date, `--finalize` with no argument chooses it.

Fixes #25.